### PR TITLE
Fix API for non-Typescript clients

### DIFF
--- a/src/test/javascript.api.test.js
+++ b/src/test/javascript.api.test.js
@@ -1,0 +1,21 @@
+const PieceTreeTextBufferBuilder = require("../index").PieceTreeTextBufferBuilder;
+const DefaultEndOfLine = require("../index").DefaultEndOfLine;
+
+describe('random tests', () => {
+    it('random insert delete', () => {
+        let pieceTreeTextBufferBuilder = new PieceTreeTextBufferBuilder();
+        pieceTreeTextBufferBuilder.acceptChunk('abc\n');
+        pieceTreeTextBufferBuilder.acceptChunk('def');
+        let pieceTreeFactory = pieceTreeTextBufferBuilder.finish(true);
+        let pieceTree = pieceTreeFactory.create(DefaultEndOfLine.LF);
+
+        expect(pieceTree.getLineCount()).toEqual(2);
+        expect(pieceTree.getLineContent(1)).toEqual('abc');
+        expect(pieceTree.getLineContent(2)).toEqual('def');
+
+        pieceTree.insert(1, '+');
+        expect(pieceTree.getLineCount()).toEqual(2);
+        expect(pieceTree.getLineContent(1)).toEqual('a+bc');
+        expect(pieceTree.getLineContent(2)).toEqual('def');
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     "outDir": "./lib",                        /* Redirect output structure to the directory. */
+    "preserveConstEnums": true,
     "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via */
   }
 }


### PR DESCRIPTION
Fixes microsoft/vscode-textbuffer#2

Includes test code that demonstrates the issue.

Typescript const enums are not exported in a way accessible to non-Typescript clients. This fixes the issue by simply utilizing the `preserveConstEnums` compiler option.

This may have a performance impact; If that is unacceptable there are other ways to fix this issue, but the included test file is useful to keep going forward.