### PR TITLE
Fix homepage url.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bugs": {
         "url": "https://github.com/microsoft/vscode-textbuffer/issues"
     },
-    "homepage": "httpshttps://github.com/microsoft/vscode-textbuffer#readme",
+    "homepage": "https://github.com/microsoft/vscode-textbuffer#readme",
     "devDependencies": {
         "@types/jest": "^24.0.13",
         "jest": "^24.8.0",


### PR DESCRIPTION
The homepage url is used when scanning the packages with tools like ORT (OSS-review-toolkit).
The homepage was not a proper url.